### PR TITLE
Remove apps to address ISO memory exhaustion issue.

### DIFF
--- a/packages/common
+++ b/packages/common
@@ -1,7 +1,6 @@
 cups
 cups-filters
 drm-kmod
-evolution
 exfat-utils
 firefox
 fish
@@ -25,7 +24,6 @@ shotwell
 slick-greeter
 system-config-printer
 unzip
-vlc
 webrtc-audio-processing
 xconfig
 xorg-minimal


### PR DESCRIPTION
Remove vlc and evolution to reduce ISO size to address memory exhaustion issue related to p3 ISO changes.